### PR TITLE
Improve forwarding in container overloads

### DIFF
--- a/stan/math/prim/fun/Phi.hpp
+++ b/stan/math/prim/fun/Phi.hpp
@@ -67,8 +67,8 @@ template <
     typename T,
     require_all_not_nonscalar_prim_or_rev_kernel_expression_t<T>* = nullptr,
     require_not_var_matrix_t<T>* = nullptr>
-inline auto Phi(const T& x) {
-  return apply_scalar_unary<Phi_fun, T>::apply(x);
+inline auto Phi(T&& x) {
+  return apply_scalar_unary<Phi_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/Phi_approx.hpp
+++ b/stan/math/prim/fun/Phi_approx.hpp
@@ -66,8 +66,8 @@ template <
     typename T,
     require_all_not_nonscalar_prim_or_rev_kernel_expression_t<T>* = nullptr,
     require_not_var_matrix_t<T>* = nullptr>
-inline auto Phi_approx(const T& x) {
-  return apply_scalar_unary<Phi_approx_fun, T>::apply(x);
+inline auto Phi_approx(T&& x) {
+  return apply_scalar_unary<Phi_approx_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/abs.hpp
+++ b/stan/math/prim/fun/abs.hpp
@@ -63,8 +63,9 @@ struct abs_fun {
  * @return Absolute value of each variable in the container.
  */
 template <typename Container, require_ad_container_t<Container>* = nullptr>
-inline auto abs(const Container& x) {
-  return apply_scalar_unary<abs_fun, Container>::apply(x);
+inline auto abs(Container&& x) {
+  return apply_scalar_unary<abs_fun, std::decay_t<Container>>::apply(
+      std::forward<Container>(x));
 }
 
 /**
@@ -77,9 +78,12 @@ inline auto abs(const Container& x) {
  */
 template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
-inline auto abs(const Container& x) {
-  return apply_vector_unary<Container>::apply(
-      x, [&](const auto& v) { return v.array().abs(); });
+inline auto abs(Container&& x) {
+  return apply_vector_unary<std::decay_t<Container>>::apply(
+      std::forward<Container>(x),
+      [&](const auto& v) {
+        return std::forward<decltype(v)>(v).array().abs();
+      });
 }
 
 namespace internal {

--- a/stan/math/prim/fun/acos.hpp
+++ b/stan/math/prim/fun/acos.hpp
@@ -65,8 +65,9 @@ struct acos_fun {
  * @return Arc cosine of each variable in the container, in radians.
  */
 template <typename Container, require_ad_container_t<Container>* = nullptr>
-inline auto acos(const Container& x) {
-  return apply_scalar_unary<acos_fun, Container>::apply(x);
+inline auto acos(Container&& x) {
+  return apply_scalar_unary<acos_fun, std::decay_t<Container>>::apply(
+      std::forward<Container>(x));
 }
 
 /**
@@ -79,9 +80,12 @@ inline auto acos(const Container& x) {
  */
 template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
-inline auto acos(const Container& x) {
-  return apply_vector_unary<Container>::apply(
-      x, [](const auto& v) { return v.array().acos(); });
+inline auto acos(Container&& x) {
+  return apply_vector_unary<std::decay_t<Container>>::apply(
+      std::forward<Container>(x),
+      [](const auto& v) {
+        return std::forward<decltype(v)>(v).array().acos();
+      });
 }
 
 namespace internal {

--- a/stan/math/prim/fun/acosh.hpp
+++ b/stan/math/prim/fun/acosh.hpp
@@ -78,8 +78,8 @@ struct acosh_fun {
  * @return Elementwise acosh of members of container.
  */
 template <typename T, require_ad_container_t<T>* = nullptr>
-inline auto acosh(const T& x) {
-  return apply_scalar_unary<acosh_fun, T>::apply(x);
+inline auto acosh(T&& x) {
+  return apply_scalar_unary<acosh_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 /**
@@ -94,8 +94,8 @@ inline auto acosh(const T& x) {
  */
 template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
-inline auto acosh(const Container& x) {
-  return apply_scalar_unary<acosh_fun, Container>::apply(x);
+inline auto acosh(Container&& x) {
+  return apply_scalar_unary<acosh_fun, std::decay_t<Container>>::apply(std::forward<Container>(x));
 }
 
 namespace internal {

--- a/stan/math/prim/fun/asin.hpp
+++ b/stan/math/prim/fun/asin.hpp
@@ -63,8 +63,9 @@ struct asin_fun {
  * @return Arcsine of each variable in the container, in radians.
  */
 template <typename Container, require_ad_container_t<Container>* = nullptr>
-inline auto asin(const Container& x) {
-  return apply_scalar_unary<asin_fun, Container>::apply(x);
+inline auto asin(Container&& x) {
+  return apply_scalar_unary<asin_fun, std::decay_t<Container>>::apply(
+      std::forward<Container>(x));
 }
 
 /**
@@ -77,9 +78,12 @@ inline auto asin(const Container& x) {
  */
 template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
-inline auto asin(const Container& x) {
-  return apply_vector_unary<Container>::apply(
-      x, [](const auto& v) { return v.array().asin(); });
+inline auto asin(Container&& x) {
+  return apply_vector_unary<std::decay_t<Container>>::apply(
+      std::forward<Container>(x),
+      [](const auto& v) {
+        return std::forward<decltype(v)>(v).array().asin();
+      });
 }
 
 namespace internal {

--- a/stan/math/prim/fun/asinh.hpp
+++ b/stan/math/prim/fun/asinh.hpp
@@ -66,8 +66,8 @@ struct asinh_fun {
  * @return Inverse hyperbolic sine of each value in the container.
  */
 template <typename T, require_ad_container_t<T>* = nullptr>
-inline auto asinh(const T& x) {
-  return apply_scalar_unary<asinh_fun, T>::apply(x);
+inline auto asinh(T&& x) {
+  return apply_scalar_unary<asinh_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 /**
@@ -80,8 +80,8 @@ inline auto asinh(const T& x) {
  */
 template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
-inline auto asinh(const Container& x) {
-  return apply_scalar_unary<asinh_fun, Container>::apply(x);
+inline auto asinh(Container&& x) {
+  return apply_scalar_unary<asinh_fun, std::decay_t<Container>>::apply(std::forward<Container>(x));
 }
 
 namespace internal {

--- a/stan/math/prim/fun/atan.hpp
+++ b/stan/math/prim/fun/atan.hpp
@@ -61,8 +61,9 @@ struct atan_fun {
  * @return Arctan of each value in x, in radians.
  */
 template <typename Container, require_ad_container_t<Container>* = nullptr>
-inline auto atan(const Container& x) {
-  return apply_scalar_unary<atan_fun, Container>::apply(x);
+inline auto atan(Container&& x) {
+  return apply_scalar_unary<atan_fun, std::decay_t<Container>>::apply(
+      std::forward<Container>(x));
 }
 
 /**
@@ -75,9 +76,12 @@ inline auto atan(const Container& x) {
  */
 template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
-inline auto atan(const Container& x) {
-  return apply_vector_unary<Container>::apply(
-      x, [](const auto& v) { return v.array().atan(); });
+inline auto atan(Container&& x) {
+  return apply_vector_unary<std::decay_t<Container>>::apply(
+      std::forward<Container>(x),
+      [](const auto& v) {
+        return std::forward<decltype(v)>(v).array().atan();
+      });
 }
 
 namespace internal {

--- a/stan/math/prim/fun/atan2.hpp
+++ b/stan/math/prim/fun/atan2.hpp
@@ -36,9 +36,13 @@ double atan2(T1 y, T2 x) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_not_var_matrix_t<T1, T2>* = nullptr>
-inline auto atan2(const T1& a, const T2& b) {
+inline auto atan2(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return atan2(c, d); }, a, b);
+      [](auto&& c, auto&& d) {
+        return atan2(std::forward<decltype(c)>(c),
+                      std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/atanh.hpp
+++ b/stan/math/prim/fun/atanh.hpp
@@ -77,8 +77,8 @@ struct atanh_fun {
  * @return Elementwise atanh of members of container.
  */
 template <typename T, require_ad_container_t<T>* = nullptr>
-inline auto atanh(const T& x) {
-  return apply_scalar_unary<atanh_fun, T>::apply(x);
+inline auto atanh(T&& x) {
+  return apply_scalar_unary<atanh_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 /**
@@ -93,8 +93,8 @@ inline auto atanh(const T& x) {
  */
 template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
-inline auto atanh(const Container& x) {
-  return apply_scalar_unary<atanh_fun, Container>::apply(x);
+inline auto atanh(Container&& x) {
+  return apply_scalar_unary<atanh_fun, std::decay_t<Container>>::apply(std::forward<Container>(x));
 }
 
 namespace internal {

--- a/stan/math/prim/fun/bessel_first_kind.hpp
+++ b/stan/math/prim/fun/bessel_first_kind.hpp
@@ -53,10 +53,13 @@ inline T2 bessel_first_kind(int v, const T2 z) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_not_var_matrix_t<T2>* = nullptr>
-inline auto bessel_first_kind(const T1& a, const T2& b) {
+inline auto bessel_first_kind(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return bessel_first_kind(c, d); }, a,
-      b);
+      [](auto&& c, auto&& d) {
+        return bessel_first_kind(std::forward<decltype(c)>(c),
+                                 std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/bessel_second_kind.hpp
+++ b/stan/math/prim/fun/bessel_second_kind.hpp
@@ -53,10 +53,13 @@ inline T2 bessel_second_kind(int v, const T2 z) {
  * @return Bessel second kind function applied to the two inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
-inline auto bessel_second_kind(const T1& a, const T2& b) {
+inline auto bessel_second_kind(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return bessel_second_kind(c, d); }, a,
-      b);
+      [](auto&& c, auto&& d) {
+        return bessel_second_kind(std::forward<decltype(c)>(c),
+                                  std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/beta.hpp
+++ b/stan/math/prim/fun/beta.hpp
@@ -67,9 +67,13 @@ inline return_type_t<T1, T2> beta(const T1 a, const T2 b) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_not_var_matrix_t<T1, T2>* = nullptr>
-inline auto beta(const T1& a, const T2& b) {
+inline auto beta(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return beta(c, d); }, a, b);
+      [](auto&& c, auto&& d) {
+        return beta(std::forward<decltype(c)>(c),
+                    std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/binary_log_loss.hpp
+++ b/stan/math/prim/fun/binary_log_loss.hpp
@@ -44,9 +44,13 @@ inline T binary_log_loss(int y, const T& y_hat) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_not_var_matrix_t<T2>* = nullptr>
-inline auto binary_log_loss(const T1& a, const T2& b) {
+inline auto binary_log_loss(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return binary_log_loss(c, d); }, a, b);
+      [](auto&& c, auto&& d) {
+        return binary_log_loss(std::forward<decltype(c)>(c),
+                               std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/binomial_coefficient_log.hpp
+++ b/stan/math/prim/fun/binomial_coefficient_log.hpp
@@ -161,12 +161,13 @@ inline return_type_t<T_n, T_k> binomial_coefficient_log(const T_n n,
  * @return Binomial coefficient log function applied to the two inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
-inline auto binomial_coefficient_log(const T1& a, const T2& b) {
+inline auto binomial_coefficient_log(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) {
-        return binomial_coefficient_log(c, d);
+      [](auto&& c, auto&& d) {
+        return binomial_coefficient_log(std::forward<decltype(c)>(c),
+                                        std::forward<decltype(d)>(d));
       },
-      a, b);
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/cbrt.hpp
+++ b/stan/math/prim/fun/cbrt.hpp
@@ -34,8 +34,8 @@ struct cbrt_fun {
 template <
     typename T, require_not_var_matrix_t<T>* = nullptr,
     require_all_not_nonscalar_prim_or_rev_kernel_expression_t<T>* = nullptr>
-inline auto cbrt(const T& x) {
-  return apply_scalar_unary<cbrt_fun, T>::apply(x);
+inline auto cbrt(T&& x) {
+  return apply_scalar_unary<cbrt_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/ceil.hpp
+++ b/stan/math/prim/fun/ceil.hpp
@@ -37,8 +37,9 @@ template <typename Container,
           require_not_container_st<std::is_arithmetic, Container>* = nullptr,
           require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
               Container>* = nullptr>
-inline auto ceil(const Container& x) {
-  return apply_scalar_unary<ceil_fun, Container>::apply(x);
+inline auto ceil(Container&& x) {
+  return apply_scalar_unary<ceil_fun, std::decay_t<Container>>::apply(
+      std::forward<Container>(x));
 }
 
 /**
@@ -52,9 +53,12 @@ inline auto ceil(const Container& x) {
 template <typename Container,
           require_container_st<std::is_arithmetic, Container>* = nullptr,
           require_not_var_matrix_t<Container>* = nullptr>
-inline auto ceil(const Container& x) {
-  return apply_vector_unary<Container>::apply(
-      x, [](const auto& v) { return v.array().ceil(); });
+inline auto ceil(Container&& x) {
+  return apply_vector_unary<std::decay_t<Container>>::apply(
+      std::forward<Container>(x),
+      [](const auto& v) {
+        return std::forward<decltype(v)>(v).array().ceil();
+      });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/choose.hpp
+++ b/stan/math/prim/fun/choose.hpp
@@ -49,9 +49,13 @@ inline int choose(int n, int k) {
  * @return Binomial coefficient function applied to the two inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
-inline auto choose(const T1& a, const T2& b) {
+inline auto choose(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return choose(c, d); }, a, b);
+      [](auto&& c, auto&& d) {
+        return choose(std::forward<decltype(c)>(c),
+                      std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/cos.hpp
+++ b/stan/math/prim/fun/cos.hpp
@@ -60,8 +60,9 @@ struct cos_fun {
  * @return Cosine of each value in x.
  */
 template <typename Container, require_ad_container_t<Container>* = nullptr>
-inline auto cos(const Container& x) {
-  return apply_scalar_unary<cos_fun, Container>::apply(x);
+inline auto cos(Container&& x) {
+  return apply_scalar_unary<cos_fun, std::decay_t<Container>>::apply(
+      std::forward<Container>(x));
 }
 
 /**
@@ -74,9 +75,12 @@ inline auto cos(const Container& x) {
  */
 template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
-inline auto cos(const Container& x) {
-  return apply_vector_unary<Container>::apply(
-      x, [&](const auto& v) { return v.array().cos(); });
+inline auto cos(Container&& x) {
+  return apply_vector_unary<std::decay_t<Container>>::apply(
+      std::forward<Container>(x),
+      [&](const auto& v) {
+        return std::forward<decltype(v)>(v).array().cos();
+      });
 }
 
 namespace internal {

--- a/stan/math/prim/fun/cosh.hpp
+++ b/stan/math/prim/fun/cosh.hpp
@@ -59,8 +59,8 @@ struct cosh_fun {
  * @return Hyberbolic cosine of x.
  */
 template <typename Container, require_ad_container_t<Container>* = nullptr>
-inline auto cosh(const Container& x) {
-  return apply_scalar_unary<cosh_fun, Container>::apply(x);
+inline auto cosh(Container&& x) {
+  return apply_scalar_unary<cosh_fun, std::decay_t<Container>>::apply(std::forward<Container>(x));
 }
 
 /**
@@ -73,9 +73,10 @@ inline auto cosh(const Container& x) {
  */
 template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
-inline auto cosh(const Container& x) {
-  return apply_vector_unary<Container>::apply(
-      x, [](const auto& v) { return v.array().cosh(); });
+inline auto cosh(Container&& x) {
+  return apply_vector_unary<std::decay_t<Container>>::apply(
+      std::forward<Container>(x),
+      [](const auto& v) { return std::forward<decltype(v)>(v).array().cosh(); });
 }
 
 namespace internal {

--- a/stan/math/prim/fun/digamma.hpp
+++ b/stan/math/prim/fun/digamma.hpp
@@ -74,8 +74,8 @@ struct digamma_fun {
 template <typename T,
           require_not_nonscalar_prim_or_rev_kernel_expression_t<T>* = nullptr,
           require_not_var_matrix_t<T>* = nullptr>
-inline auto digamma(const T& x) {
-  return apply_scalar_unary<digamma_fun, T>::apply(x);
+inline auto digamma(T&& x) {
+  return apply_scalar_unary<digamma_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/erf.hpp
+++ b/stan/math/prim/fun/erf.hpp
@@ -35,8 +35,8 @@ template <
     typename T,
     require_all_not_nonscalar_prim_or_rev_kernel_expression_t<T>* = nullptr,
     require_not_var_matrix_t<T>* = nullptr>
-inline auto erf(const T& x) {
-  return apply_scalar_unary<erf_fun, T>::apply(x);
+inline auto erf(T&& x) {
+  return apply_scalar_unary<erf_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/erfc.hpp
+++ b/stan/math/prim/fun/erfc.hpp
@@ -36,8 +36,8 @@ template <
     typename T,
     require_all_not_nonscalar_prim_or_rev_kernel_expression_t<T>* = nullptr,
     require_not_var_matrix_t<T>* = nullptr>
-inline auto erfc(const T& x) {
-  return apply_scalar_unary<erfc_fun, T>::apply(x);
+inline auto erfc(T&& x) {
+  return apply_scalar_unary<erfc_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -68,8 +68,9 @@ struct exp_fun {
  * @return Elementwise application of exponentiation to the argument.
  */
 template <typename Container, require_ad_container_t<Container>* = nullptr>
-inline auto exp(const Container& x) {
-  return apply_scalar_unary<exp_fun, Container>::apply(x);
+inline auto exp(Container&& x) {
+  return apply_scalar_unary<exp_fun, std::decay_t<Container>>::apply(
+      std::forward<Container>(x));
 }
 
 /**
@@ -82,9 +83,10 @@ inline auto exp(const Container& x) {
  */
 template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
-inline auto exp(const Container& x) {
-  return apply_vector_unary<Container>::apply(
-      x, [](const auto& v) { return v.array().exp(); });
+inline auto exp(Container&& x) {
+  return apply_vector_unary<std::decay_t<Container>>::apply(
+      std::forward<Container>(x),
+      [](const auto& v) { return std::forward<decltype(v)>(v).array().exp(); });
 }
 
 namespace internal {

--- a/stan/math/prim/fun/exp2.hpp
+++ b/stan/math/prim/fun/exp2.hpp
@@ -39,8 +39,8 @@ template <
     typename T,
     require_all_not_nonscalar_prim_or_rev_kernel_expression_t<T>* = nullptr,
     require_not_var_matrix_t<T>* = nullptr>
-inline auto exp2(const T& x) {
-  return apply_scalar_unary<exp2_fun, T>::apply(x);
+inline auto exp2(T&& x) {
+  return apply_scalar_unary<exp2_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/expm1.hpp
+++ b/stan/math/prim/fun/expm1.hpp
@@ -36,8 +36,8 @@ template <
     typename T,
     require_all_not_nonscalar_prim_or_rev_kernel_expression_t<T>* = nullptr,
     require_not_var_matrix_t<T>* = nullptr>
-inline auto expm1(const T& x) {
-  return apply_scalar_unary<expm1_fun, T>::apply(x);
+inline auto expm1(T&& x) {
+  return apply_scalar_unary<expm1_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/fabs.hpp
+++ b/stan/math/prim/fun/fabs.hpp
@@ -48,8 +48,8 @@ template <typename Container,
           require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
               Container>* = nullptr,
           require_not_stan_scalar_t<Container>* = nullptr>
-inline auto fabs(const Container& x) {
-  return apply_scalar_unary<fabs_fun, Container>::apply(x);
+inline auto fabs(Container&& x) {
+  return apply_scalar_unary<fabs_fun, std::decay_t<Container>>::apply(std::forward<Container>(x));
 }
 
 /**
@@ -62,9 +62,10 @@ inline auto fabs(const Container& x) {
  */
 template <typename Container,
           require_container_st<std::is_arithmetic, Container>* = nullptr>
-inline auto fabs(const Container& x) {
-  return apply_vector_unary<Container>::apply(
-      x, [](const auto& v) { return v.array().abs(); });
+inline auto fabs(Container&& x) {
+  return apply_vector_unary<std::decay_t<Container>>::apply(
+      std::forward<Container>(x),
+      [](const auto& v) { return std::forward<decltype(v)>(v).array().abs(); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/falling_factorial.hpp
+++ b/stan/math/prim/fun/falling_factorial.hpp
@@ -80,10 +80,13 @@ inline return_type_t<T> falling_factorial(const T& x, int n) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_not_var_matrix_t<T1, T2>* = nullptr>
-inline auto falling_factorial(const T1& a, const T2& b) {
+inline auto falling_factorial(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return falling_factorial(c, d); }, a,
-      b);
+      [](auto&& c, auto&& d) {
+        return falling_factorial(std::forward<decltype(c)>(c),
+                                 std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/fdim.hpp
+++ b/stan/math/prim/fun/fdim.hpp
@@ -35,9 +35,13 @@ inline double fdim(T1 x, T2 y) {
  * @return Fdim function applied to the two inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
-inline auto fdim(const T1& a, const T2& b) {
+inline auto fdim(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return fdim(c, d); }, a, b);
+      [](auto&& c, auto&& d) {
+        return fdim(std::forward<decltype(c)>(c),
+                    std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/floor.hpp
+++ b/stan/math/prim/fun/floor.hpp
@@ -42,8 +42,8 @@ struct floor_fun {
  * @return Greatest integer <= each value in x.
  */
 template <typename Container, require_ad_container_t<Container>* = nullptr>
-inline auto floor(const Container& x) {
-  return apply_scalar_unary<floor_fun, Container>::apply(x);
+inline auto floor(Container&& x) {
+  return apply_scalar_unary<floor_fun, std::decay_t<Container>>::apply(std::forward<Container>(x));
 }
 
 /**
@@ -57,9 +57,10 @@ inline auto floor(const Container& x) {
 template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr,
           require_not_var_matrix_t<Container>* = nullptr>
-inline auto floor(const Container& x) {
-  return apply_vector_unary<Container>::apply(
-      x, [](const auto& v) { return v.array().floor(); });
+inline auto floor(Container&& x) {
+  return apply_vector_unary<std::decay_t<Container>>::apply(
+      std::forward<Container>(x),
+      [](const auto& v) { return std::forward<decltype(v)>(v).array().floor(); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/fmax.hpp
+++ b/stan/math/prim/fun/fmax.hpp
@@ -33,9 +33,13 @@ inline double fmax(T1 x, T2 y) {
  * @return fmax function applied to the two inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
-inline auto fmax(const T1& a, const T2& b) {
+inline auto fmax(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return fmax(c, d); }, a, b);
+      [](auto&& c, auto&& d) {
+        return fmax(std::forward<decltype(c)>(c),
+                    std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/fmin.hpp
+++ b/stan/math/prim/fun/fmin.hpp
@@ -33,9 +33,13 @@ inline double fmin(T1 x, T2 y) {
  * @return fmin function applied to the two inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
-inline auto fmin(const T1& a, const T2& b) {
+inline auto fmin(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return fmin(c, d); }, a, b);
+      [](auto&& c, auto&& d) {
+        return fmin(std::forward<decltype(c)>(c),
+                    std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/fmod.hpp
+++ b/stan/math/prim/fun/fmod.hpp
@@ -34,13 +34,14 @@ inline double fmod(const T1& a, const T2& b) {
  * @return fmod function applied to the two inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
-inline auto fmod(const T1& a, const T2& b) {
+inline auto fmod(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) {
+      [](auto&& c, auto&& d) {
         using std::fmod;
-        return fmod(c, d);
+        return fmod(std::forward<decltype(c)>(c),
+                    std::forward<decltype(d)>(d));
       },
-      a, b);
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/gamma_p.hpp
+++ b/stan/math/prim/fun/gamma_p.hpp
@@ -87,9 +87,12 @@ inline double gamma_p(double z, double a) {
  * @return gamma_p function applied to the two inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
-inline auto gamma_p(const T1& a, const T2& b) {
+inline auto gamma_p(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return gamma_p(c, d); }, a, b);
+      [](auto&& c, auto&& d) {
+        return gamma_p(std::forward<decltype(c)>(c), std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/gamma_q.hpp
+++ b/stan/math/prim/fun/gamma_q.hpp
@@ -65,9 +65,13 @@ inline double gamma_q(double x, double a) { return boost::math::gamma_q(x, a); }
  * @return gamma_q function applied to the two inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
-inline auto gamma_q(const T1& a, const T2& b) {
+inline auto gamma_q(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return gamma_q(c, d); }, a, b);
+      [](auto&& c, auto&& d) {
+        return gamma_q(std::forward<decltype(c)>(c),
+                       std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/hypot.hpp
+++ b/stan/math/prim/fun/hypot.hpp
@@ -39,9 +39,13 @@ inline double hypot(T1 x, T2 y) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
               T1, T2>* = nullptr>
-inline auto hypot(const T1& a, const T2& b) {
+inline auto hypot(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return hypot(c, d); }, a, b);
+      [](auto&& c, auto&& d) {
+        return hypot(std::forward<decltype(c)>(c),
+                     std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/inv.hpp
+++ b/stan/math/prim/fun/inv.hpp
@@ -34,8 +34,8 @@ struct inv_fun {
 template <
     typename T, require_not_container_st<std::is_arithmetic, T>* = nullptr,
     require_all_not_nonscalar_prim_or_rev_kernel_expression_t<T>* = nullptr>
-inline auto inv(const T& x) {
-  return apply_scalar_unary<inv_fun, T>::apply(x);
+inline auto inv(T&& x) {
+  return apply_scalar_unary<inv_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 /**
@@ -50,9 +50,10 @@ template <typename Container,
           require_container_st<std::is_arithmetic, Container>* = nullptr,
           require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
               Container>* = nullptr>
-inline auto inv(const Container& x) {
-  return apply_vector_unary<Container>::apply(
-      x, [](const auto& v) { return v.array().inverse(); });
+inline auto inv(Container&& x) {
+  return apply_vector_unary<std::decay_t<Container>>::apply(
+      std::forward<Container>(x),
+      [](const auto& v) { return std::forward<decltype(v)>(v).array().inverse(); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/inv_Phi.hpp
+++ b/stan/math/prim/fun/inv_Phi.hpp
@@ -177,8 +177,8 @@ template <
     typename T,
     require_all_not_nonscalar_prim_or_rev_kernel_expression_t<T>* = nullptr,
     require_not_var_matrix_t<T>* = nullptr>
-inline auto inv_Phi(const T& x) {
-  return apply_scalar_unary<inv_Phi_fun, T>::apply(x);
+inline auto inv_Phi(T&& x) {
+  return apply_scalar_unary<inv_Phi_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/inv_cloglog.hpp
+++ b/stan/math/prim/fun/inv_cloglog.hpp
@@ -90,8 +90,8 @@ struct inv_cloglog_fun {
  * @return 1 - exp(-exp()) applied to each value in x.
  */
 template <typename Container, require_ad_container_t<Container>* = nullptr>
-inline auto inv_cloglog(const Container& x) {
-  return apply_scalar_unary<inv_cloglog_fun, Container>::apply(x);
+inline auto inv_cloglog(Container&& x) {
+  return apply_scalar_unary<inv_cloglog_fun, std::decay_t<Container>>::apply(std::forward<Container>(x));
 }
 
 /**
@@ -104,9 +104,12 @@ inline auto inv_cloglog(const Container& x) {
  */
 template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
-inline auto inv_cloglog(const Container& x) {
-  return apply_vector_unary<Container>::apply(
-      x, [](const auto& v) { return 1 - (-v.array().exp()).exp(); });
+inline auto inv_cloglog(Container&& x) {
+  return apply_vector_unary<std::decay_t<Container>>::apply(
+      std::forward<Container>(x),
+      [](const auto& v) {
+        return 1 - (-std::forward<decltype(v)>(v).array().exp()).exp();
+      });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/inv_erfc.hpp
+++ b/stan/math/prim/fun/inv_erfc.hpp
@@ -48,8 +48,8 @@ template <
     require_all_not_nonscalar_prim_or_rev_kernel_expression_t<T>* = nullptr,
     require_not_var_matrix_t<T>* = nullptr,
     require_not_arithmetic_t<T>* = nullptr>
-inline auto inv_erfc(const T& x) {
-  return apply_scalar_unary<inv_erfc_fun, T>::apply(x);
+inline auto inv_erfc(T&& x) {
+  return apply_scalar_unary<inv_erfc_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/inv_sqrt.hpp
+++ b/stan/math/prim/fun/inv_sqrt.hpp
@@ -45,8 +45,8 @@ struct inv_sqrt_fun {
  * @return inverse square root of each value in x.
  */
 template <typename Container, require_ad_container_t<Container>* = nullptr>
-inline auto inv_sqrt(const Container& x) {
-  return apply_scalar_unary<inv_sqrt_fun, Container>::apply(x);
+inline auto inv_sqrt(Container&& x) {
+  return apply_scalar_unary<inv_sqrt_fun, std::decay_t<Container>>::apply(std::forward<Container>(x));
 }
 
 /**
@@ -59,14 +59,16 @@ inline auto inv_sqrt(const Container& x) {
  */
 template <typename Container, require_not_var_matrix_t<Container>* = nullptr,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
-inline auto inv_sqrt(const Container& x) {
+inline auto inv_sqrt(Container&& x) {
 // Eigen 3.4.0 has precision issues on ARM64 with vectorised rsqrt
 // Resolved in current master branch, below can be removed on next release
 #ifdef __aarch64__
-  return apply_scalar_unary<inv_sqrt_fun, Container>::apply(x);
+  return apply_scalar_unary<inv_sqrt_fun, std::decay_t<Container>>::apply(
+      std::forward<Container>(x));
 #else
-  return apply_vector_unary<Container>::apply(
-      x, [](const auto& v) { return v.array().rsqrt(); });
+  return apply_vector_unary<std::decay_t<Container>>::apply(
+      std::forward<Container>(x),
+      [](const auto& v) { return std::forward<decltype(v)>(v).array().rsqrt(); });
 #endif
 }
 

--- a/stan/math/prim/fun/inv_square.hpp
+++ b/stan/math/prim/fun/inv_square.hpp
@@ -34,9 +34,12 @@ inline auto inv_square(const Container& x) {
  */
 template <typename Container,
           require_container_st<std::is_arithmetic, Container>* = nullptr>
-inline auto inv_square(const Container& x) {
-  return apply_vector_unary<Container>::apply(
-      x, [](const auto& v) { return v.array().square().inverse(); });
+inline auto inv_square(Container&& x) {
+  return apply_vector_unary<std::decay_t<Container>>::apply(
+      std::forward<Container>(x),
+      [](const auto& v) {
+        return std::forward<decltype(v)>(v).array().square().inverse();
+      });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/lambert_w.hpp
+++ b/stan/math/prim/fun/lambert_w.hpp
@@ -80,8 +80,8 @@ struct lambert_wm1_fun {
  */
 template <typename T, require_not_stan_scalar_t<T>* = nullptr,
           require_not_var_matrix_t<T>* = nullptr>
-inline auto lambert_w0(const T& x) {
-  return apply_scalar_unary<internal::lambert_w0_fun, T>::apply(x);
+inline auto lambert_w0(T&& x) {
+  return apply_scalar_unary<internal::lambert_w0_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 /**
@@ -95,8 +95,8 @@ inline auto lambert_w0(const T& x) {
  */
 template <typename T, require_not_stan_scalar_t<T>* = nullptr,
           require_not_var_matrix_t<T>* = nullptr>
-inline auto lambert_wm1(const T& x) {
-  return apply_scalar_unary<internal::lambert_wm1_fun, T>::apply(x);
+inline auto lambert_wm1(T&& x) {
+  return apply_scalar_unary<internal::lambert_wm1_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/lbeta.hpp
+++ b/stan/math/prim/fun/lbeta.hpp
@@ -127,9 +127,13 @@ return_type_t<T1, T2> lbeta(const T1 a, const T2 b) {
  * @return lbeta function applied to the two inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
-inline auto lbeta(const T1& a, const T2& b) {
+inline auto lbeta(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return lbeta(c, d); }, a, b);
+      [](auto&& c, auto&& d) {
+        return lbeta(std::forward<decltype(c)>(c),
+                     std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/ldexp.hpp
+++ b/stan/math/prim/fun/ldexp.hpp
@@ -36,9 +36,13 @@ inline double ldexp(T1 a, int b) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
               T1, T2>* = nullptr>
-inline auto ldexp(const T1& a, const T2& b) {
+inline auto ldexp(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return ldexp(c, d); }, a, b);
+      [](auto&& c, auto&& d) {
+        return ldexp(std::forward<decltype(c)>(c),
+                     std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/lgamma.hpp
+++ b/stan/math/prim/fun/lgamma.hpp
@@ -116,8 +116,8 @@ struct lgamma_fun {
  */
 template <typename T, require_not_var_matrix_t<T>* = nullptr,
           require_not_nonscalar_prim_or_rev_kernel_expression_t<T>* = nullptr>
-inline auto lgamma(const T& x) {
-  return apply_scalar_unary<lgamma_fun, T>::apply(x);
+inline auto lgamma(T&& x) {
+  return apply_scalar_unary<lgamma_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/lmgamma.hpp
+++ b/stan/math/prim/fun/lmgamma.hpp
@@ -70,9 +70,13 @@ inline return_type_t<T> lmgamma(int k, T x) {
  * inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
-inline auto lmgamma(const T1& a, const T2& b) {
+inline auto lmgamma(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return lmgamma(c, d); }, a, b);
+      [](auto&& c, auto&& d) {
+        return lmgamma(std::forward<decltype(c)>(c),
+                       std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/lmultiply.hpp
+++ b/stan/math/prim/fun/lmultiply.hpp
@@ -43,9 +43,13 @@ inline return_type_t<T1, T2> lmultiply(const T1 a, const T2 b) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_not_var_matrix_t<T1, T2>* = nullptr>
-inline auto lmultiply(const T1& a, const T2& b) {
+inline auto lmultiply(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return lmultiply(c, d); }, a, b);
+      [](auto&& c, auto&& d) {
+        return lmultiply(std::forward<decltype(c)>(c),
+                         std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log.hpp
+++ b/stan/math/prim/fun/log.hpp
@@ -67,8 +67,9 @@ struct log_fun {
  * @return Elementwise application of natural log to the argument.
  */
 template <typename Container, require_ad_container_t<Container>* = nullptr>
-inline auto log(const Container& x) {
-  return apply_scalar_unary<log_fun, Container>::apply(x);
+inline auto log(Container&& x) {
+  return apply_scalar_unary<log_fun, std::decay_t<Container>>::apply(
+      std::forward<Container>(x));
 }
 
 /**
@@ -81,9 +82,10 @@ inline auto log(const Container& x) {
  */
 template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
-inline auto log(const Container& x) {
-  return apply_vector_unary<Container>::apply(
-      x, [](const auto& v) { return v.array().log(); });
+inline auto log(Container&& x) {
+  return apply_vector_unary<std::decay_t<Container>>::apply(
+      std::forward<Container>(x),
+      [](const auto& v) { return std::forward<decltype(v)>(v).array().log(); });
 }
 
 namespace internal {

--- a/stan/math/prim/fun/log10.hpp
+++ b/stan/math/prim/fun/log10.hpp
@@ -58,8 +58,8 @@ struct log10_fun {
  * @return Log base-10 applied to each value in x.
  */
 template <typename Container, require_ad_container_t<Container>* = nullptr>
-inline auto log10(const Container& x) {
-  return apply_scalar_unary<log10_fun, Container>::apply(x);
+inline auto log10(Container&& x) {
+  return apply_scalar_unary<log10_fun, std::decay_t<Container>>::apply(std::forward<Container>(x));
 }
 
 /**
@@ -72,9 +72,10 @@ inline auto log10(const Container& x) {
  */
 template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
-inline auto log10(const Container& x) {
-  return apply_vector_unary<Container>::apply(
-      x, [](const auto& v) { return v.array().log10(); });
+inline auto log10(Container&& x) {
+  return apply_vector_unary<std::decay_t<Container>>::apply(
+      std::forward<Container>(x),
+      [](const auto& v) { return std::forward<decltype(v)>(v).array().log10(); });
 }
 
 namespace internal {

--- a/stan/math/prim/fun/log1m.hpp
+++ b/stan/math/prim/fun/log1m.hpp
@@ -70,8 +70,8 @@ struct log1m_fun {
 template <
     typename T, require_not_var_matrix_t<T>* = nullptr,
     require_all_not_nonscalar_prim_or_rev_kernel_expression_t<T>* = nullptr>
-inline auto log1m(const T& x) {
-  return apply_scalar_unary<log1m_fun, T>::apply(x);
+inline auto log1m(T&& x) {
+  return apply_scalar_unary<log1m_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log1m_exp.hpp
+++ b/stan/math/prim/fun/log1m_exp.hpp
@@ -80,8 +80,8 @@ struct log1m_exp_fun {
 template <
     typename T, require_not_var_matrix_t<T>* = nullptr,
     require_all_not_nonscalar_prim_or_rev_kernel_expression_t<T>* = nullptr>
-inline auto log1m_exp(const T& x) {
-  return apply_scalar_unary<log1m_exp_fun, T>::apply(x);
+inline auto log1m_exp(T&& x) {
+  return apply_scalar_unary<log1m_exp_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log1m_inv_logit.hpp
+++ b/stan/math/prim/fun/log1m_inv_logit.hpp
@@ -82,9 +82,10 @@ struct log1m_inv_logit_fun {
  */
 template <typename T, require_not_var_matrix_t<T>* = nullptr,
           require_not_nonscalar_prim_or_rev_kernel_expression_t<T>* = nullptr>
-inline typename apply_scalar_unary<log1m_inv_logit_fun, T>::return_t
-log1m_inv_logit(const T& x) {
-  return apply_scalar_unary<log1m_inv_logit_fun, T>::apply(x);
+inline typename apply_scalar_unary<log1m_inv_logit_fun, std::decay_t<T>>::return_t
+log1m_inv_logit(T&& x) {
+  return apply_scalar_unary<log1m_inv_logit_fun, std::decay_t<T>>::apply(
+      std::forward<T>(x));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log1p.hpp
+++ b/stan/math/prim/fun/log1p.hpp
@@ -79,8 +79,8 @@ struct log1p_fun {
 template <typename T,
           require_not_nonscalar_prim_or_rev_kernel_expression_t<T>* = nullptr,
           require_not_var_matrix_t<T>* = nullptr>
-inline auto log1p(const T& x) {
-  return apply_scalar_unary<log1p_fun, T>::apply(x);
+inline auto log1p(T&& x) {
+  return apply_scalar_unary<log1p_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log1p_exp.hpp
+++ b/stan/math/prim/fun/log1p_exp.hpp
@@ -75,8 +75,8 @@ struct log1p_exp_fun {
 template <typename T,
           require_not_nonscalar_prim_or_rev_kernel_expression_t<T>* = nullptr,
           require_not_var_matrix_t<T>* = nullptr>
-inline auto log1p_exp(const T& x) {
-  return apply_scalar_unary<log1p_exp_fun, T>::apply(x);
+inline auto log1p_exp(T&& x) {
+  return apply_scalar_unary<log1p_exp_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log2.hpp
+++ b/stan/math/prim/fun/log2.hpp
@@ -46,8 +46,8 @@ struct log2_fun {
  */
 template <typename T, require_not_var_matrix_t<T>* = nullptr,
           require_not_nonscalar_prim_or_rev_kernel_expression_t<T>* = nullptr>
-inline auto log2(const T& x) {
-  return apply_scalar_unary<log2_fun, T>::apply(x);
+inline auto log2(T&& x) {
+  return apply_scalar_unary<log2_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_diff_exp.hpp
+++ b/stan/math/prim/fun/log_diff_exp.hpp
@@ -66,9 +66,13 @@ inline return_type_t<T1, T2> log_diff_exp(const T1 x, const T2 y) {
  * @return log_diff_exp function applied to the two inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
-inline auto log_diff_exp(const T1& a, const T2& b) {
+inline auto log_diff_exp(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return log_diff_exp(c, d); }, a, b);
+      [](auto&& c, auto&& d) {
+        return log_diff_exp(std::forward<decltype(c)>(c),
+                            std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_falling_factorial.hpp
+++ b/stan/math/prim/fun/log_falling_factorial.hpp
@@ -72,10 +72,13 @@ inline return_type_t<T1, T2> log_falling_factorial(const T1 x, const T2 n) {
  * @return log_falling_factorial function applied to the two inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
-inline auto log_falling_factorial(const T1& a, const T2& b) {
+inline auto log_falling_factorial(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return log_falling_factorial(c, d); },
-      a, b);
+      [](auto&& c, auto&& d) {
+        return log_falling_factorial(std::forward<decltype(c)>(c),
+                                     std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_inv_logit.hpp
+++ b/stan/math/prim/fun/log_inv_logit.hpp
@@ -81,8 +81,8 @@ struct log_inv_logit_fun {
 template <typename T,
           require_not_nonscalar_prim_or_rev_kernel_expression_t<T>* = nullptr,
           require_not_var_matrix_t<T>* = nullptr>
-inline auto log_inv_logit(const T& x) {
-  return apply_scalar_unary<log_inv_logit_fun, T>::apply(x);
+inline auto log_inv_logit(T&& x) {
+  return apply_scalar_unary<log_inv_logit_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_inv_logit_diff.hpp
+++ b/stan/math/prim/fun/log_inv_logit_diff.hpp
@@ -52,10 +52,13 @@ inline return_type_t<T1, T2> log_inv_logit_diff(const T1& x, const T2& y) {
  * @return log_inv_logit_diff function applied to the two inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
-inline auto log_inv_logit_diff(const T1& a, const T2& b) {
+inline auto log_inv_logit_diff(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return log_inv_logit_diff(c, d); }, a,
-      b);
+      [](auto&& c, auto&& d) {
+        return log_inv_logit_diff(std::forward<decltype(c)>(c),
+                                  std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_modified_bessel_first_kind.hpp
+++ b/stan/math/prim/fun/log_modified_bessel_first_kind.hpp
@@ -232,12 +232,13 @@ inline return_type_t<T1, T2, double> log_modified_bessel_first_kind(
  * @return log_modified_bessel_first_kind function applied to the two inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
-inline auto log_modified_bessel_first_kind(const T1& a, const T2& b) {
+inline auto log_modified_bessel_first_kind(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) {
-        return log_modified_bessel_first_kind(c, d);
+      [](auto&& c, auto&& d) {
+        return log_modified_bessel_first_kind(std::forward<decltype(c)>(c),
+                                              std::forward<decltype(d)>(d));
       },
-      a, b);
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_rising_factorial.hpp
+++ b/stan/math/prim/fun/log_rising_factorial.hpp
@@ -70,10 +70,13 @@ inline return_type_t<T1, T2> log_rising_factorial(const T1& x, const T2& n) {
  * @return log_rising_factorial function applied to the two inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
-inline auto log_rising_factorial(const T1& a, const T2& b) {
+inline auto log_rising_factorial(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return log_rising_factorial(c, d); },
-      a, b);
+      [](auto&& c, auto&& d) {
+        return log_rising_factorial(std::forward<decltype(c)>(c),
+                                    std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_softmax.hpp
+++ b/stan/math/prim/fun/log_softmax.hpp
@@ -41,14 +41,17 @@ namespace math {
  */
 template <typename Container, require_st_arithmetic<Container>* = nullptr,
           require_container_t<Container>* = nullptr>
-inline auto log_softmax(const Container& x) {
+inline auto log_softmax(Container&& x) {
   check_nonzero_size("log_softmax", "v", x);
   return make_holder(
-      [](const auto& a) {
-        return apply_vector_unary<ref_type_t<Container>>::apply(
-            a, [](const auto& v) { return v.array() - log_sum_exp(v); });
+      [](auto&& a) {
+        return apply_vector_unary<ref_type_t<std::decay_t<Container>>>::apply(
+            std::forward<decltype(a)>(a),
+            [](const auto& v) {
+              return std::forward<decltype(v)>(v).array() - log_sum_exp(v);
+            });
       },
-      to_ref(x));
+      to_ref(std::forward<Container>(x)));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_sum_exp.hpp
+++ b/stan/math/prim/fun/log_sum_exp.hpp
@@ -79,8 +79,9 @@ inline return_type_t<T1, T2> log_sum_exp(const T2& a, const T1& b) {
  * @return The log of the sum of the exponentiated vector values.
  */
 template <typename T, require_container_st<std::is_arithmetic, T>* = nullptr>
-inline auto log_sum_exp(const T& x) {
-  return apply_vector_unary<T>::reduce(x, [&](const auto& v) {
+inline auto log_sum_exp(T&& x) {
+  return apply_vector_unary<std::decay_t<T>>::reduce(
+      std::forward<T>(x), [&](auto&& v) {
     if (v.size() == 0) {
       return NEGATIVE_INFTY;
     }
@@ -104,9 +105,13 @@ inline auto log_sum_exp(const T& x) {
  * @return log_sum_exp function applied to the two inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
-inline auto log_sum_exp(const T1& a, const T2& b) {
+inline auto log_sum_exp(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return log_sum_exp(c, d); }, a, b);
+      [](auto&& c, auto&& d) {
+        return log_sum_exp(std::forward<decltype(c)>(c),
+                           std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/logit.hpp
+++ b/stan/math/prim/fun/logit.hpp
@@ -87,8 +87,8 @@ struct logit_fun {
  * @return elementwise logit of container elements
  */
 template <typename Container, require_ad_container_t<Container>* = nullptr>
-inline auto logit(const Container& x) {
-  return apply_scalar_unary<logit_fun, Container>::apply(x);
+inline auto logit(Container&& x) {
+  return apply_scalar_unary<logit_fun, std::decay_t<Container>>::apply(std::forward<Container>(x));
 }
 
 /**
@@ -104,14 +104,19 @@ inline auto logit(const Container& x) {
  */
 template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
-inline auto logit(const Container& x) {
+inline auto logit(Container&& x) {
   return make_holder(
-      [](const auto& v_ref) {
-        return apply_vector_unary<ref_type_t<Container>>::apply(
-            v_ref,
-            [](const auto& v) { return (v.array() / (1 - v.array())).log(); });
+      [](auto&& v_ref) {
+        return apply_vector_unary<ref_type_t<std::decay_t<Container>>>::apply(
+            std::forward<decltype(v_ref)>(v_ref),
+            [](const auto& v) {
+              return (
+                         std::forward<decltype(v)>(v).array()
+                         / (1 - std::forward<decltype(v)>(v).array()))
+                  .log();
+            });
       },
-      to_ref(x));
+      to_ref(std::forward<Container>(x)));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/minus.hpp
+++ b/stan/math/prim/fun/minus.hpp
@@ -27,9 +27,10 @@ inline auto minus(const T& x) {
  * @return Container where each element is negated.
  */
 template <typename T>
-inline auto minus(const std::vector<T>& x) {
+inline auto minus(std::vector<T>&& x) {
   return apply_vector_unary<std::vector<T>>::apply(
-      x, [](const auto& v) { return -v; });
+      std::forward<std::vector<T>>(x),
+      [](auto&& v) { return -std::forward<decltype(v)>(v); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/modified_bessel_first_kind.hpp
+++ b/stan/math/prim/fun/modified_bessel_first_kind.hpp
@@ -63,12 +63,13 @@ inline double modified_bessel_first_kind(int v, int z) {
  * @return modified_bessel_first_kind function applied to the two inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
-inline auto modified_bessel_first_kind(const T1& a, const T2& b) {
+inline auto modified_bessel_first_kind(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) {
-        return modified_bessel_first_kind(c, d);
+      [](auto&& c, auto&& d) {
+        return modified_bessel_first_kind(std::forward<decltype(c)>(c),
+                                          std::forward<decltype(d)>(d));
       },
-      a, b);
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/modified_bessel_second_kind.hpp
+++ b/stan/math/prim/fun/modified_bessel_second_kind.hpp
@@ -55,12 +55,13 @@ inline T2 modified_bessel_second_kind(int v, const T2 z) {
  * @return modified_bessel_second_kind function applied to the two inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
-inline auto modified_bessel_second_kind(const T1& a, const T2& b) {
+inline auto modified_bessel_second_kind(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) {
-        return modified_bessel_second_kind(c, d);
+      [](auto&& c, auto&& d) {
+        return modified_bessel_second_kind(std::forward<decltype(c)>(c),
+                                           std::forward<decltype(d)>(d));
       },
-      a, b);
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/multiply_log.hpp
+++ b/stan/math/prim/fun/multiply_log.hpp
@@ -67,9 +67,13 @@ inline return_type_t<T_a, T_b> multiply_log(const T_a a, const T_b b) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_not_var_matrix_t<T1, T2>* = nullptr>
-inline auto multiply_log(const T1& a, const T2& b) {
+inline auto multiply_log(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return multiply_log(c, d); }, a, b);
+      [](auto&& c, auto&& d) {
+        return multiply_log(std::forward<decltype(c)>(c),
+                            std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/norm1.hpp
+++ b/stan/math/prim/fun/norm1.hpp
@@ -31,9 +31,10 @@ inline double norm1(const T& v) {
  * @return L1 norm of v.
  */
 template <typename Container, require_std_vector_t<Container>* = nullptr>
-inline auto norm1(const Container& x) {
-  return apply_vector_unary<Container>::reduce(
-      x, [](const auto& v) { return norm1(v); });
+inline auto norm1(Container&& x) {
+  return apply_vector_unary<std::decay_t<Container>>::reduce(
+      std::forward<Container>(x),
+      [](auto&& v) { return norm1(std::forward<decltype(v)>(v)); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/norm2.hpp
+++ b/stan/math/prim/fun/norm2.hpp
@@ -31,9 +31,10 @@ inline double norm2(const T& v) {
  * @return L2 norm of v.
  */
 template <typename Container, require_std_vector_t<Container>* = nullptr>
-inline auto norm2(const Container& x) {
-  return apply_vector_unary<Container>::reduce(
-      x, [](const auto& v) { return norm2(v); });
+inline auto norm2(Container&& x) {
+  return apply_vector_unary<std::decay_t<Container>>::reduce(
+      std::forward<Container>(x),
+      [](auto&& v) { return norm2(std::forward<decltype(v)>(v)); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/owens_t.hpp
+++ b/stan/math/prim/fun/owens_t.hpp
@@ -74,9 +74,13 @@ inline double owens_t(double h, double a) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_not_var_and_matrix_types<T1, T2>* = nullptr>
-inline auto owens_t(const T1& a, const T2& b) {
+inline auto owens_t(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return owens_t(c, d); }, a, b);
+      [](auto&& c, auto&& d) {
+        return owens_t(std::forward<decltype(c)>(c),
+                       std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/pow.hpp
+++ b/stan/math/prim/fun/pow.hpp
@@ -108,10 +108,11 @@ inline auto pow(const T1& a, const T2& b) {
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_not_matrix_st<is_var, T1, T2>* = nullptr,
           require_all_arithmetic_t<base_type_t<T1>, base_type_t<T2>>* = nullptr>
-inline auto pow(const T1& a, const T2& b) {
+inline auto pow(T1&& a, T2&& b) {
   return apply_scalar_binary(
       // Qualified pow since only Arithmetic types are accepted here
-      [](const auto& c, const auto& d) { return stan::math::pow(c, d); }, a, b);
+      [](const auto& c, const auto& d) { return stan::math::pow(c, d); },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/fun/rising_factorial.hpp
+++ b/stan/math/prim/fun/rising_factorial.hpp
@@ -78,10 +78,13 @@ inline return_type_t<T> rising_factorial(const T& x, int n) {
  * @return rising_factorial function applied to the two inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
-inline auto rising_factorial(const T1& a, const T2& b) {
+inline auto rising_factorial(T1&& a, T2&& b) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return rising_factorial(c, d); }, a,
-      b);
+      [](auto&& c, auto&& d) {
+        return rising_factorial(std::forward<decltype(c)>(c),
+                                std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(a), std::forward<T2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/round.hpp
+++ b/stan/math/prim/fun/round.hpp
@@ -36,8 +36,8 @@ template <typename Container,
           require_not_container_st<std::is_arithmetic, Container>* = nullptr,
           require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
               Container>* = nullptr>
-inline auto round(const Container& x) {
-  return apply_scalar_unary<round_fun, Container>::apply(x);
+inline auto round(Container&& x) {
+  return apply_scalar_unary<round_fun, std::decay_t<Container>>::apply(std::forward<Container>(x));
 }
 
 /**
@@ -50,9 +50,10 @@ inline auto round(const Container& x) {
  */
 template <typename Container,
           require_container_st<std::is_arithmetic, Container>* = nullptr>
-inline auto round(const Container& x) {
-  return apply_vector_unary<Container>::apply(
-      x, [](const auto& v) { return v.array().round(); });
+inline auto round(Container&& x) {
+  return apply_vector_unary<std::decay_t<Container>>::apply(
+      std::forward<Container>(x),
+      [](const auto& v) { return std::forward<decltype(v)>(v).array().round(); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/sd.hpp
+++ b/stan/math/prim/fun/sd.hpp
@@ -23,10 +23,11 @@ namespace math {
  */
 template <typename T, require_container_t<T>* = nullptr,
           require_not_st_var<T>* = nullptr>
-inline auto sd(const T& m) {
+inline auto sd(T&& m) {
   using std::sqrt;
 
-  return apply_vector_unary<T>::reduce(m, [](const auto& x) {
+  return apply_vector_unary<std::decay_t<T>>::reduce(
+      std::forward<T>(m), [](auto&& x) {
     check_nonzero_size("sd", "x", x);
 
     if (x.size() == 1) {

--- a/stan/math/prim/fun/select.hpp
+++ b/stan/math/prim/fun/select.hpp
@@ -23,8 +23,8 @@ namespace math {
 template <typename T_true, typename T_false,
           typename ReturnT = return_type_t<T_true, T_false>,
           require_all_stan_scalar_t<T_true, T_false>* = nullptr>
-inline ReturnT select(const bool c, const T_true y_true,
-                      const T_false y_false) {
+inline ReturnT select(const bool c, T_true&& y_true,
+                      T_false&& y_false) {
   return c ? ReturnT(y_true) : ReturnT(y_false);
 }
 
@@ -80,16 +80,16 @@ template <typename T_true, typename T_false,
                                               plain_type_t<T_true>>,
           require_container_t<T_true>* = nullptr,
           require_stan_scalar_t<T_false>* = nullptr>
-inline ReturnT select(const bool c, const T_true& y_true,
-                      const T_false& y_false) {
+inline ReturnT select(const bool c, T_true&& y_true,
+                      T_false&& y_false) {
   if (c) {
     return y_true;
   } else {
     return apply_scalar_binary(
-        [](const auto& y_true_inner, const auto& y_false_inner) {
-          return y_false_inner;
+        [](auto&& y_true_inner, auto&& y_false_inner) {
+          return std::forward<decltype(y_false_inner)>(y_false_inner);
         },
-        y_true, y_false);
+        std::forward<T_true>(y_true), std::forward<T_false>(y_false));
   }
 }
 
@@ -119,10 +119,10 @@ inline ReturnT select(const bool c, const T_true y_true,
                       const T_false y_false) {
   if (c) {
     return apply_scalar_binary(
-        [](const auto& y_true_inner, const auto& y_false_inner) {
-          return y_true_inner;
+        [](auto&& y_true_inner, auto&& y_false_inner) {
+          return std::forward<decltype(y_true_inner)>(y_true_inner);
         },
-        y_true, y_false);
+        std::forward<T_true>(y_true), std::forward<T_false>(y_false));
   } else {
     return y_false;
   }

--- a/stan/math/prim/fun/sign.hpp
+++ b/stan/math/prim/fun/sign.hpp
@@ -39,8 +39,8 @@ struct sign_fun {
  * @return Elementwise sign of members of container.
  */
 template <typename T, require_container_t<T>* = nullptr>
-inline auto sign(const T& x) {
-  return apply_scalar_unary<sign_fun, T>::apply(x);
+inline auto sign(T&& x) {
+  return apply_scalar_unary<sign_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/sin.hpp
+++ b/stan/math/prim/fun/sin.hpp
@@ -59,8 +59,9 @@ struct sin_fun {
  * @return Sine of each value in x.
  */
 template <typename T, require_ad_container_t<T>* = nullptr>
-inline auto sin(const T& x) {
-  return apply_scalar_unary<sin_fun, T>::apply(x);
+inline auto sin(T&& x) {
+  return apply_scalar_unary<sin_fun, std::decay_t<T>>::apply(
+      std::forward<T>(x));
 }
 
 /**
@@ -73,9 +74,10 @@ inline auto sin(const T& x) {
  */
 template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
-inline auto sin(const Container& x) {
-  return apply_vector_unary<Container>::apply(
-      x, [&](const auto& v) { return v.array().sin(); });
+inline auto sin(Container&& x) {
+  return apply_vector_unary<std::decay_t<Container>>::apply(
+      std::forward<Container>(x),
+      [&](const auto& v) { return std::forward<decltype(v)>(v).array().sin(); });
 }
 
 namespace internal {

--- a/stan/math/prim/fun/sinh.hpp
+++ b/stan/math/prim/fun/sinh.hpp
@@ -57,8 +57,8 @@ struct sinh_fun {
  * @return Hyperbolic sine of each variable in x.
  */
 template <typename Container, require_ad_container_t<Container>* = nullptr>
-inline auto sinh(const Container& x) {
-  return apply_scalar_unary<sinh_fun, Container>::apply(x);
+inline auto sinh(Container&& x) {
+  return apply_scalar_unary<sinh_fun, std::decay_t<Container>>::apply(std::forward<Container>(x));
 }
 
 /**
@@ -71,9 +71,10 @@ inline auto sinh(const Container& x) {
  */
 template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
-inline auto sinh(const Container& x) {
-  return apply_vector_unary<Container>::apply(
-      x, [](const auto& v) { return v.array().sinh(); });
+inline auto sinh(Container&& x) {
+  return apply_vector_unary<std::decay_t<Container>>::apply(
+      std::forward<Container>(x),
+      [](const auto& v) { return std::forward<decltype(v)>(v).array().sinh(); });
 }
 
 namespace internal {

--- a/stan/math/prim/fun/sqrt.hpp
+++ b/stan/math/prim/fun/sqrt.hpp
@@ -57,8 +57,8 @@ struct sqrt_fun {
  * @return Square root of each value in x.
  */
 template <typename Container, require_ad_container_t<Container>* = nullptr>
-inline auto sqrt(const Container& x) {
-  return apply_scalar_unary<sqrt_fun, Container>::apply(x);
+inline auto sqrt(Container&& x) {
+  return apply_scalar_unary<sqrt_fun, std::decay_t<Container>>::apply(std::forward<Container>(x));
 }
 
 /**
@@ -72,9 +72,10 @@ inline auto sqrt(const Container& x) {
 template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr,
           require_not_var_matrix_t<Container>* = nullptr>
-inline auto sqrt(const Container& x) {
-  return apply_vector_unary<Container>::apply(
-      x, [](const auto& v) { return v.array().sqrt(); });
+inline auto sqrt(Container&& x) {
+  return apply_vector_unary<std::decay_t<Container>>::apply(
+      std::forward<Container>(x),
+      [](const auto& v) { return std::forward<decltype(v)>(v).array().sqrt(); });
 }
 
 namespace internal {

--- a/stan/math/prim/fun/square.hpp
+++ b/stan/math/prim/fun/square.hpp
@@ -50,8 +50,8 @@ struct square_fun {
  * @return Each value in x squared.
  */
 template <typename Container, require_ad_container_t<Container>* = nullptr>
-inline auto square(const Container& x) {
-  return apply_scalar_unary<square_fun, Container>::apply(x);
+inline auto square(Container&& x) {
+  return apply_scalar_unary<square_fun, std::decay_t<Container>>::apply(std::forward<Container>(x));
 }
 
 /**
@@ -64,9 +64,10 @@ inline auto square(const Container& x) {
  */
 template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
-inline auto square(const Container& x) {
-  return apply_vector_unary<Container>::apply(
-      x, [](const auto& v) { return v.array().square(); });
+inline auto square(Container&& x) {
+  return apply_vector_unary<std::decay_t<Container>>::apply(
+      std::forward<Container>(x),
+      [](const auto& v) { return std::forward<decltype(v)>(v).array().square(); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/step.hpp
+++ b/stan/math/prim/fun/step.hpp
@@ -58,8 +58,8 @@ struct step_fun {
  * @return Elementwise step of members of container.
  */
 template <typename T, require_container_t<T>* = nullptr>
-inline auto step(const T& x) {
-  return apply_scalar_unary<step_fun, T>::apply(x);
+inline auto step(T&& x) {
+  return apply_scalar_unary<step_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/tan.hpp
+++ b/stan/math/prim/fun/tan.hpp
@@ -59,8 +59,9 @@ struct tan_fun {
  * @return Tangent of each value in x.
  */
 template <typename Container, require_ad_container_t<Container>* = nullptr>
-inline auto tan(const Container& x) {
-  return apply_scalar_unary<tan_fun, Container>::apply(x);
+inline auto tan(Container&& x) {
+  return apply_scalar_unary<tan_fun, std::decay_t<Container>>::apply(
+      std::forward<Container>(x));
 }
 
 /**
@@ -73,9 +74,12 @@ inline auto tan(const Container& x) {
  */
 template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
-inline auto tan(const Container& x) {
-  return apply_vector_unary<Container>::apply(
-      x, [](const auto& v) { return v.array().tan(); });
+inline auto tan(Container&& x) {
+  return apply_vector_unary<std::decay_t<Container>>::apply(
+      std::forward<Container>(x),
+      [](const auto& v) {
+        return std::forward<decltype(v)>(v).array().tan();
+      });
 }
 
 namespace internal {

--- a/stan/math/prim/fun/tanh.hpp
+++ b/stan/math/prim/fun/tanh.hpp
@@ -59,8 +59,8 @@ struct tanh_fun {
  * @return Hyperbolic tangent of each value in x.
  */
 template <typename Container, require_ad_container_t<Container>* = nullptr>
-inline auto tanh(const Container& x) {
-  return apply_scalar_unary<tanh_fun, Container>::apply(x);
+inline auto tanh(Container&& x) {
+  return apply_scalar_unary<tanh_fun, std::decay_t<Container>>::apply(std::forward<Container>(x));
 }
 
 /**
@@ -73,9 +73,10 @@ inline auto tanh(const Container& x) {
  */
 template <typename Container,
           require_container_bt<std::is_arithmetic, Container>* = nullptr>
-inline auto tanh(const Container& x) {
-  return apply_vector_unary<Container>::apply(
-      x, [](const auto& v) { return v.array().tanh(); });
+inline auto tanh(Container&& x) {
+  return apply_vector_unary<std::decay_t<Container>>::apply(
+      std::forward<Container>(x),
+      [](const auto& v) { return std::forward<decltype(v)>(v).array().tanh(); });
 }
 
 namespace internal {

--- a/stan/math/prim/fun/tgamma.hpp
+++ b/stan/math/prim/fun/tgamma.hpp
@@ -50,8 +50,8 @@ template <
     typename T,
     require_all_not_nonscalar_prim_or_rev_kernel_expression_t<T>* = nullptr,
     require_not_var_matrix_t<T>* = nullptr>
-inline auto tgamma(const T& x) {
-  return apply_scalar_unary<tgamma_fun, T>::apply(x);
+inline auto tgamma(T&& x) {
+  return apply_scalar_unary<tgamma_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/to_complex.hpp
+++ b/stan/math/prim/fun/to_complex.hpp
@@ -37,10 +37,13 @@ constexpr inline std::complex<stan::real_return_t<T, S>> to_complex(
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr,
           require_all_st_stan_scalar<T1, T2>* = nullptr>
-inline auto to_complex(const T1& re, const T2& im) {
+inline auto to_complex(T1&& re, T2&& im) {
   return apply_scalar_binary(
-      [](const auto& c, const auto& d) { return stan::math::to_complex(c, d); },
-      re, im);
+      [](auto&& c, auto&& d) {
+        return stan::math::to_complex(std::forward<decltype(c)>(c),
+                                      std::forward<decltype(d)>(d));
+      },
+      std::forward<T1>(re), std::forward<T2>(im));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/to_int.hpp
+++ b/stan/math/prim/fun/to_int.hpp
@@ -71,8 +71,8 @@ struct to_int_fun {
  */
 template <typename Container,
           require_std_vector_st<std::is_arithmetic, Container>* = nullptr>
-inline auto to_int(const Container& x) {
-  return apply_scalar_unary<to_int_fun, Container>::apply(x);
+inline auto to_int(Container&& x) {
+  return apply_scalar_unary<to_int_fun, std::decay_t<Container>>::apply(std::forward<Container>(x));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/trigamma.hpp
+++ b/stan/math/prim/fun/trigamma.hpp
@@ -155,8 +155,8 @@ struct trigamma_fun {
  */
 template <typename T,
           require_not_nonscalar_prim_or_rev_kernel_expression_t<T>* = nullptr>
-inline auto trigamma(const T& x) {
-  return apply_scalar_unary<trigamma_fun, T>::apply(x);
+inline auto trigamma(T&& x) {
+  return apply_scalar_unary<trigamma_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/trunc.hpp
+++ b/stan/math/prim/fun/trunc.hpp
@@ -39,8 +39,8 @@ struct trunc_fun {
  */
 template <typename T, require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
                           T>* = nullptr>
-inline auto trunc(const T& x) {
-  return apply_scalar_unary<trunc_fun, T>::apply(x);
+inline auto trunc(T&& x) {
+  return apply_scalar_unary<trunc_fun, std::decay_t<T>>::apply(std::forward<T>(x));
 }
 
 }  // namespace math


### PR DESCRIPTION
## Summary
- forward container arguments in numerous unary and binary math overloads
- update lambdas to preserve value category through apply functions

## Testing
- `./runTests.py test/unit/math/prim/fun/log_test.cpp`
- `./runTests.py test/unit/math/prim/fun/logit_test.cpp`


------
https://chatgpt.com/codex/tasks/task_b_684c73367a88832b9a53e2ea24ee9570